### PR TITLE
Automatically Build Book on Every Commit

### DIFF
--- a/.github/workflows/buildlatex.yml
+++ b/.github/workflows/buildlatex.yml
@@ -1,0 +1,20 @@
+name: Build LaTeX document
+on: [push]
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+      - name: Compile LaTeX document
+        uses: dante-ev/latex-action@latest
+        with:
+          root_file: DynamicalBook.tex
+          working_directory: book
+          args: -pdf -latexoption=-file-line-error -latexoption=-interaction=nonstopmode -latexoption=-shell-escape
+          extra_system_packages: python-pygments
+      - name: Uploads the document
+        uses: actions/upload-artifact@v2
+        with:
+          name: DynamicalBook
+          path: book/DynamicalBook.pdf


### PR DESCRIPTION
This adds a github workflow to automatically build the book every time you push a new commit to the repository. Then the book pdf is saved as an "artifact" associated with the commit.

I can also set this up so that it, for instance, uploads the book pdf to a website or something, if you want to have an automatically-updating download link.